### PR TITLE
Add reference to automated build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   lakesuperior:
-    build: .
+    image: scossu/lakesuperior:stable
     volumes:
       - lakesuperior:/data
     ports:


### PR DESCRIPTION
This adds an image reference to the automated build so that the Quick Start instructions will pull the existing container image instead of building a new one. This should complete the Docker integration (for now).