### PR TITLE
Remove extraneous characters from anchor link. Fixes #48.

### DIFF
--- a/lakesuperior/endpoints/ldp.py
+++ b/lakesuperior/endpoints/ldp.py
@@ -251,7 +251,7 @@ def post_resource(parent_uid):
     hdr = {'Location' : uri}
 
     if mimetype and not is_rdf:
-        hdr['Link'] = '<{0}/fcr:metadata>; rel="describedby"; anchor="<{0}>"'\
+        hdr['Link'] = '<{0}/fcr:metadata>; rel="describedby"; anchor="{0}"'\
                 .format(uri)
 
     out_headers.update(hdr)


### PR DESCRIPTION
Fixes #48 

Changes in this pull request:

- Remove extraneous (`<>`) character from "anchor" link returned in POST.