### PR TITLE
Allow creating resources providing RDF bytestring. Also resolves #56.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -152,10 +152,22 @@ Create an LDP-NR (non-RDF source)::
     ...     uid, stream=BytesIO(data), mimetype='text/plain')
     '_create_'
 
+Create or replace providing a serialized RDF byte stream::
+
+    >>> uid = '/rsrc_from_rdf'
+    >>> rdf = b'<#a1> a <http://ex.org/type#B> .'
+    >>> rsrc_api.create_or_replace(uid, rdf_data=rdf, rdf_fmt='turtle')
+
+Relative URIs such as ``<#a1>`` will be resolved relative to the resource URI.
+
 Create under a known parent, providing a slug (POST style)::
 
     >>> rsrc_api.create('/rsrc_from_stream', 'res1')
 
+This will create ``/rsrc_from_stream/res1`` if not existing; otherwise the
+resource URI will have a random UUID4 instead of ``res1``.
+
+To use a random UUID by default, use ``None`` for the second argument.
 
 Retrieve Resources
 ~~~~~~~~~~~~~~~~~~

--- a/lakesuperior/model/ldp_factory.py
+++ b/lakesuperior/model/ldp_factory.py
@@ -78,7 +78,9 @@ class LdpFactory:
 
 
     @staticmethod
-    def from_provided(uid, mimetype=None, stream=None, graph=None, **kwargs):
+    def from_provided(
+            uid, mimetype=None, stream=None, graph=None, rdf_data=None,
+            rdf_fmt=None, **kwargs):
         r"""
         Create and LDPR instance from provided data.
 
@@ -92,12 +94,17 @@ class LdpFactory:
         :param IOStream stream: The provided data stream.
         :param rdflib.Graph graph: Initial graph to populate the
             resource with. This can be used for LDP-RS and LDP-NR types alike.
+        :param bytes rdf_data: Serialized RDF to build the initial graph.
+        :param str rdf_fmt: Serialization format of RDF data.
         :param \*\*kwargs: Arguments passed to the LDP class constructor.
 
         :raise ValueError: if ``mimetype`` is specified but no data stream is
             provided.
         """
         uri = nsc['fcres'][uid]
+        if rdf_data:
+            graph = Graph().parse(
+                data=rdf_data, format=rdf_fmt, publicID=nsc['fcres'][uid])
 
         provided_imr = Graph(identifier=uri)
         if graph:


### PR DESCRIPTION
Fixes #56 

Changes in this pull request:

- Allow creating resources providing RDF bytestring.

Notes & caveats:

This also introduces new functionality whereas previously a RDF data stream had to be parsed  into a graph to be passed to the resource API creation methods. 