### PR TITLE
Fix Travis build error compiling Spookyhash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
   - pip install -e .
 script:
   - python setup.py test
+env:
+  - CFLAGS="-std=c99"
 
 deploy:
     provider: pypi


### PR DESCRIPTION
Fixes #

Changes in this pull request:

- Added env flag to CI script to avoid a compile error from the `restricted` keyword in Spookyhash code

Notes & caveats:

- The error only appeared in the 3.6 build. The Xenial / Python 3.7 build was unaffected.

@scossu
